### PR TITLE
Lock http-proxy version

### DIFF
--- a/deploymeteor.sh
+++ b/deploymeteor.sh
@@ -80,7 +80,7 @@ prepserver)
     echo "Installing or updating http-proxy..."
     mkdir -p $NODEPROXY_DIR
     cd $NODEPROXY_DIR
-    npm install http-proxy &> /dev/null
+    npm install http-proxy@0.10.3 &> /dev/null
 
     #install PhantomJS
     echo "Installing PhantomJS..."


### PR DESCRIPTION
Subsequent versions of http-proxy break nodeproxy.js due to api changes. The simplest solution is to lock http-proxy at the last compatible version.
